### PR TITLE
fix(types): annotate optimized image type in adaptOpenGraphImages

### DIFF
--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -1,6 +1,9 @@
 import { isUnpicCompatible, unpicOptimizer, astroAssetsOptimizer } from './images-optimization';
 import type { ImageMetadata } from 'astro';
 import type { OpenGraph } from '@astrolib/seo';
+import type { ImagesOptimizer } from './images-optimization';
+/** The optimized image shape returned by our ImagesOptimizer */
+type OptimizedImage = Awaited<ReturnType<ImagesOptimizer>>[0];
 
 const load = async function () {
   let images: Record<string, () => Promise<unknown>> | undefined = undefined;
@@ -71,7 +74,7 @@ export const adaptOpenGraphImages = async (
           };
         }
 
-        let _image;
+        let _image: OptimizedImage | undefined;
 
         if (
           typeof resolvedImage === 'string' &&


### PR DESCRIPTION
## Summary

Removes the `ts(7043)` implicit-any hint by introducing a typed alias for `ImagesOptimizer` output and annotating `_image` explicitly:

- Imports `ImagesOptimizer` from `./images-optimization`
- Defines `type OptimizedImage = Awaited<ReturnType<ImagesOptimizer>>[0]`
- Annotates `_image: OptimizedImage | undefined`

No functional changes. Type-level only.

## CI Outcome

- ✅ `astro check`: no errors, warnings, or hints  
- ✅ `eslint .`: clean  
- ✅ `prettier --check .`: all files formatted
