### PR TITLE
fix(types): make applyGetPermalinks TypeScript 6 strict-safe

### DIFF
--- a/src/utils/permalinks.ts
+++ b/src/utils/permalinks.ts
@@ -104,31 +104,35 @@ export const getAsset = (path: string): string =>
 const definitivePermalink = (permalink: string): string => createPath(BASE_PATHNAME, permalink);
 
 /** */
-export const applyGetPermalinks = (menu: object = {}) => {
+type MenuHref = { type?: string; url?: string };
+
+/** */
+export const applyGetPermalinks = (menu: unknown = {}): unknown => {
   if (Array.isArray(menu)) {
     return menu.map((item) => applyGetPermalinks(item));
   } else if (typeof menu === 'object' && menu !== null) {
-    const obj = {};
-    for (const key in menu) {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(menu)) {
       if (key === 'href') {
-        if (typeof menu[key] === 'string') {
-          obj[key] = getPermalink(menu[key]);
-        } else if (typeof menu[key] === 'object') {
-          if (menu[key].type === 'home') {
-            obj[key] = getHomePermalink();
-          } else if (menu[key].type === 'blog') {
-            obj[key] = getBlogPermalink();
-          } else if (menu[key].type === 'asset') {
-            obj[key] = getAsset(menu[key].url);
-          } else if (menu[key].url) {
-            obj[key] = getPermalink(menu[key].url, menu[key].type);
+        if (typeof value === 'string') {
+          result[key] = getPermalink(value);
+        } else if (typeof value === 'object' && value !== null) {
+          const href = value as MenuHref;
+          if (href.type === 'home') {
+            result[key] = getHomePermalink();
+          } else if (href.type === 'blog') {
+            result[key] = getBlogPermalink();
+          } else if (href.type === 'asset') {
+            result[key] = getAsset(href.url ?? '');
+          } else if (href.url) {
+            result[key] = getPermalink(href.url, href.type);
           }
         }
       } else {
-        obj[key] = applyGetPermalinks(menu[key]);
+        result[key] = applyGetPermalinks(value);
       }
     }
-    return obj;
+    return result;
   }
   return menu;
 };


### PR DESCRIPTION
## What

Makes `applyGetPermalinks` (`src/utils/permalinks.ts`) compile cleanly under **TypeScript 6.0**, where `strict` / `noImplicitAny` is on by default.

Fixes #707.

## Why

The function took `menu: object = {}`, iterated with `for...in`, and read/wrote via bracket indexing (`menu[key]`, `obj[key]`) with no return-type annotation. With `noImplicitAny` enabled, that produced **19 errors** (17× `ts7053`, 1× `ts7023`, 1× `ts7024`) — indexing a bare `object`/`{}` and an un-annotated recursive return type.

## Change

- `menu: unknown` with an explicit `: unknown` return type (breaks the recursive implicit-`any` inference)
- `Object.entries(menu)` instead of `for...in` + bracket indexing (no indexing of a non-indexable type)
- `Record<string, unknown>` accumulator instead of `const obj = {}`
- A small `MenuHref` type to narrow the `href` object branch

Runtime behavior is unchanged — it's a pure typing fix.

## Verification

With `typescript@6` installed, `npx astro check` no longer reports any errors in `permalinks.ts` (was 19, now 0). `eslint` and `prettier` pass on the changed file.

## Note (out of scope)

While verifying, `astro check` under TS 6 also surfaced the **same `{}`-indexing pattern in `src/utils/blog.ts`** (4× `ts7053`) and an unrelated `ts(2882)` for a `@fontsource-variable/*` side-effect import in `CustomStyles.astro`. Those are left out of this PR to keep it focused on #707, but they're part of the same TS 6 readiness effort — happy to follow up with a PR for `blog.ts` if you'd like.
