### PR TITLE
fix(types): make blog getStaticPaths TypeScript 6 strict-safe

### DIFF
--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -1,7 +1,7 @@
 import type { PaginateFunction } from 'astro';
 import { getCollection, render } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
-import type { Post } from '~/types';
+import type { Post, Taxonomy } from '~/types';
 import { APP_BLOG } from 'astrowind:config';
 import { cleanSlug, trimSlash, BLOG_BASE, POST_PERMALINK_PATTERN, CATEGORY_BASE, TAG_BASE } from './permalinks';
 
@@ -198,10 +198,10 @@ export const getStaticPathsBlogCategory = async ({ paginate }: { paginate: Pagin
   if (!isBlogEnabled || !isBlogCategoryRouteEnabled) return [];
 
   const posts = await fetchPosts();
-  const categories = {};
+  const categories: Record<string, Taxonomy> = {};
   posts.map((post) => {
     if (post.category?.slug) {
-      categories[post.category?.slug] = post.category;
+      categories[post.category.slug] = post.category;
     }
   });
 
@@ -222,11 +222,11 @@ export const getStaticPathsBlogTag = async ({ paginate }: { paginate: PaginateFu
   if (!isBlogEnabled || !isBlogTagRouteEnabled) return [];
 
   const posts = await fetchPosts();
-  const tags = {};
+  const tags: Record<string, Taxonomy> = {};
   posts.map((post) => {
     if (Array.isArray(post.tags)) {
       post.tags.map((tag) => {
-        tags[tag?.slug] = tag;
+        tags[tag.slug] = tag;
       });
     }
   });


### PR DESCRIPTION
## What

Makes `getStaticPathsBlogCategory` and `getStaticPathsBlogTag` (`src/utils/blog.ts`) compile cleanly under **TypeScript 6.0** (`strict` / `noImplicitAny` on by default).

Companion to #708; related to #707. Same root cause, different file.

## Why

Both functions build an untyped accumulator (`const categories = {}` / `const tags = {}`) and index it by string. Under `noImplicitAny`, indexing a bare `{}` is an error — 4× `ts7053` total (the write into the accumulator and the read in `props`).

## Change

- Type both accumulators as `Record<string, Taxonomy>` — `Taxonomy` is the existing type behind `Post.category` and `Post.tags[]`, so no new shapes are introduced.
- Drop the now-redundant optional chaining on the index keys (`post.category.slug` / `tag.slug`): the surrounding guards already narrow them to defined, and `Taxonomy.slug` is a required `string`.

Runtime behavior is unchanged — pure typing.

## Verification

With `typescript@6`, `npx astro check` reports 0 errors in `blog.ts` (was 4). `eslint` and `prettier` pass on the changed file.

Together with #708 (`permalinks.ts`), this clears all the implicit-any errors TS 6 surfaces in `src/utils`. (One unrelated `ts(2882)` for a `@fontsource-variable/*` side-effect import in `CustomStyles.astro` remains — different root cause, not addressed here.)
