### PR TITLE
fix(types): declare fontsource modules for TypeScript 6 (ts2882)

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -3,3 +3,8 @@
 /// <reference types="astro/client" />
 /// <reference types="vite/client" />
 /// <reference types="../vendor/integration/types.d.ts" />
+
+// Fontsource packages ship CSS only (no type declarations); declare them so
+// side-effect imports type-check under TypeScript 6 strict (ts2882).
+declare module '@fontsource-variable/*';
+declare module '@fontsource/*';


### PR DESCRIPTION
## What

Resolves the `ts(2882)` error on the fontsource side-effect import in `src/components/CustomStyles.astro` under **TypeScript 6.0** (`strict` on by default).

Related to #707. Third and final piece of vanilla-template TS 6 readiness, alongside #708 (`permalinks.ts`) and #709 (`blog.ts`).

## Why

`CustomStyles.astro` loads the font via a side-effect import:

```ts
import '@fontsource-variable/inter';
```

Fontsource packages ship **CSS only** — no `.d.ts`. Under TS 6, a side-effect import of a module with no type declarations is an error:

```
src/components/CustomStyles.astro:2:8 - error ts(2882): Cannot find module or type declarations for side-effect import of '@fontsource-variable/inter'.
```

## Change

Add ambient module declarations in `src/env.d.ts`:

```ts
declare module '@fontsource-variable/*';
declare module '@fontsource/*';
```

(Both scopes are declared since the commented-out font options in `CustomStyles.astro` include non-variable `@fontsource/*` families.) Purely a type-level shim — Vite still resolves and bundles the CSS, so build output is unchanged.

## Verification

With `typescript@6`, `npx astro check` no longer reports the `ts(2882)` error (`CustomStyles.astro` is clean). `eslint` and `prettier` pass.

With #708 and #709 also applied, `astro check` reports **0 errors** on a vanilla AstroWind install under TypeScript 6.
