### PR TITLE
fix(styles): unquote var() in font-family declarations

### DIFF
--- a/src/assets/styles/tailwind.css
+++ b/src/assets/styles/tailwind.css
@@ -14,10 +14,10 @@
   --color-muted: var(--aw-color-text-muted);
 
   --font-sans:
-    'var(--aw-font-sans, ui-sans-serif)', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    var(--aw-font-sans, ui-sans-serif), ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
-  --font-serif: 'var(--aw-font-serif, ui-serif)', ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
-  --font-heading: 'var(--aw-font-heading, ui-sans-serif)', ui-sans-serif, system-ui, sans-serif;
+  --font-serif: var(--aw-font-serif, ui-serif), ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
+  --font-heading: var(--aw-font-heading, ui-sans-serif), ui-sans-serif, system-ui, sans-serif;
 
   --animate-fade: fadeInUp 1s both;
 


### PR DESCRIPTION
The var(--aw-font-sans, ...), var(--aw-font-serif, ...), and var(--aw-font-heading, ...) primary font references were wrapped in quotes, turning them into literal strings instead of resolving the CSS variable.

Fixes #714