### PR TITLE
Unquote the font-family var() references so the theme fonts apply (#714)

### DIFF
--- a/src/assets/styles/tailwind.css
+++ b/src/assets/styles/tailwind.css
@@ -14,10 +14,10 @@
   --color-muted: var(--aw-color-text-muted);
 
   --font-sans:
-    'var(--aw-font-sans, ui-sans-serif)', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    var(--aw-font-sans, ui-sans-serif), ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
-  --font-serif: 'var(--aw-font-serif, ui-serif)', ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
-  --font-heading: 'var(--aw-font-heading, ui-sans-serif)', ui-sans-serif, system-ui, sans-serif;
+  --font-serif: var(--aw-font-serif, ui-serif), ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
+  --font-heading: var(--aw-font-heading, ui-sans-serif), ui-sans-serif, system-ui, sans-serif;
 
   --animate-fade: fadeInUp 1s both;
 


### PR DESCRIPTION
Fixes #714.

### The bug

In `src/assets/styles/tailwind.css` the three font tokens wrap their `var()` calls in quotes:

```css
--font-sans: 'var(--aw-font-sans, ui-sans-serif)', ui-sans-serif, system-ui, sans-serif, ...;
```

A quoted string in `font-family` is a *literal family name*, not a substitution. The browser looks for a font actually named `var(--aw-font-sans, ui-sans-serif)`, fails to find one, and falls through to the next family in the list — so `--aw-font-sans` (and its serif/heading siblings) never take effect, and the Inter set in `CustomStyles.astro` never renders. It goes unnoticed because the fallback is a reasonable system sans.

The quoting belongs on the *value* — `CustomStyles.astro` already correctly declares `--aw-font-sans: 'Inter Variable'` — not on the `var()` call.

### The fix

Remove the quotes around the three `var()` references. One-line change each; no other behaviour is affected.

### Verification

Confirmed on a build of this template with a custom font in `CustomStyles.astro`, using Chrome DevTools Protocol `CSS.getPlatformFontsForNode` to read the font the browser *actually painted* with (rather than the computed `font-family` string, which does not reveal the failed lookup):

| | before | after |
|---|---|---|
| painted font | `Segoe UI` (fallback) | `Nunito Variable` (the configured font) |
| `document.fonts.check('700 60px "Nunito Variable"')` | `false` | `true` |

The variable-weight axis also renders correctly after the fix (rendered text width grows monotonically from weight 200 → 900), confirming the face is genuinely in use and not merely loaded.

---
*Created by Claude Code*
