### PR TITLE
feat: add Knocket live chat widget component

### DIFF
--- a/src/components/common/KnocketWidget.astro
+++ b/src/components/common/KnocketWidget.astro
@@ -1,0 +1,7 @@
+---
+import { ANALYTICS } from 'astrowind:config';
+
+const id = ANALYTICS?.vendors?.knocket?.id ? String(ANALYTICS.vendors.knocket.id) : '';
+---
+
+{id && <script is:inline async src={`https://trtc.io/knocket-sdk/sdk.js?identifier=${id}`} />}


### PR DESCRIPTION
Adds a KnocketWidget.astro component alongside the existing Analytics.astro, following the same astrowind:config pattern.

Knocket is a 100% free live chat widget — free forever, no ads, no seat limits. Renders only when ANALYTICS.vendors.knocket.id is set, so it's opt-in with zero impact on existing sites.

More info: https://trtc.io/solutions/knocket